### PR TITLE
Refactor CI workflow for Maven with services and JDK 17

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,65 @@
+name: ci-backend
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping || exit 1"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
+      rabbitmq:
+        image: rabbitmq:3-management
+        ports:
+          - 5672:5672
+          - 15672:15672
+        env:
+          RABBITMQ_DEFAULT_USER: guest
+          RABBITMQ_DEFAULT_PASS: guest
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for Redis and RabbitMQ to start..."
+          for i in {1..30}; do
+            nc -z localhost 6379 && nc -z localhost 5672 && echo "Services are up!" && break
+            echo "Waiting..."
+            sleep 2
+          done
+
+      - name: Build and Test with Maven
+        run: |
+          cd backend
+          mvn -B clean verify -Dspring.profiles.active=test
+
+      - name: Update dependency graph
+        run: |
+          cd backend
+          mvn com.github.ferstl:depgraph-maven-plugin:4.0.1:graph


### PR DESCRIPTION
Updated CI workflow to use JDK 17, added Redis and RabbitMQ services, and modified build steps.